### PR TITLE
Fix issue related to missing config for servers + add error handling to ;sa

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,6 +94,12 @@ async def on_ready():
 	print("Servers I am currently in:")
 	for server in bot.guilds:
 		print(server)
+		# this is so if we're added to a server while we're offline we deal with it
+		try:
+			gs.get(server)
+		except KeyError:
+			print("Server not found in servers.json - adding example config")
+			gs.add_guild(server)
 	print("")
 
 

--- a/roxbot/settings/settings.py
+++ b/roxbot/settings/settings.py
@@ -367,16 +367,22 @@ class Settings:
 			self_assign["enabled"] = 0
 			await ctx.send("'self_assign' was disabled :cry:")
 		elif selection == "addrole":
-			if role.id in self_assign["roles"]:
-				return await ctx.send("{} is already a self-assignable role.".format(role.name))
-			self_assign["roles"].append(role.id)
-			await ctx.send('Role "{}" added'.format(str(role)))
+			try:
+				if role.id in self_assign["roles"]:
+					return await ctx.send("{} is already a self-assignable role.".format(role.name))
+				self_assign["roles"].append(role.id)
+				await ctx.send('Role "{}" added'.format(str(role)))
+			except AttributeError:
+				return await ctx.send("Role param incorrect. Check you spelt it correctly")
 		elif selection == "removerole":
-			if role.id in self_assign["roles"]:
-				self_assign["roles"].remove(role.id)
-				await ctx.send('"{}" has been removed from the self-assignable roles.'.format(str(role)))
-			else:
-				return await ctx.send("That role was not in the list.")
+			try:
+				if role.id in self_assign["roles"]:
+					self_assign["roles"].remove(role.id)
+					await ctx.send('"{}" has been removed from the self-assignable roles.'.format(str(role)))
+				else:
+					return await ctx.send("That role was not in the list.")
+			except AttributeError:
+				return await ctx.send("Role param incorrect. Check you spelt it correctly")
 		else:
 			return await ctx.send("No valid option given.")
 		return self.guild_settings.update(self_assign, "self_assign")


### PR DESCRIPTION
**Missing config**
This issue occurred when the bot user was added to a server while it was offline, or was started for the first time, with the bot user already being in a server. This was caused by the adding of servers happening with the event `on_guild_join` and `on_guild_remove`

The fix was while the bot is printing the servers it is in, it tries to load the config for that server. If it cannot, it creates the config, assuming it has just been added.

**Error handling**

When an incorrect role is passed, `role.id` results in an attribute error. As such, a try except was added, so instead of an error, the user has some idea what they did wrong.